### PR TITLE
WiFi: Remove unnecessary list item reflow function

### DIFF
--- a/source/views/WiFi.js
+++ b/source/views/WiFi.js
@@ -74,11 +74,6 @@ enyo.kind({
 		}]
 	}
 	],
-	reflow: function(inSender , inEvent) {
-		this.log("sender:", inSender, ", event:", inEvent);
-		this.inherited(arguments);
-		this.render;
-	},
 	handlers: {
 		onmousedown: "pressed",
 		ondragstart: "released",


### PR DESCRIPTION
Unnecessary and a serious log spammer.
Correcting the malformed render() call made it even worse.

By all means check this on TP and in different orientations (for example).
This works for me in browser and on Nexus 4.