### PR TITLE
Search preferences

### DIFF
--- a/source/views/SearchPreferences.js
+++ b/source/views/SearchPreferences.js
@@ -1,0 +1,103 @@
+enyo.kind({
+	name: "SearchPreferences",
+	layoutKind: "FittableRowsLayout",
+	palm: false,
+	preferredSearch: undefined,
+	components:[
+		{kind: "onyx.Toolbar",
+		 style: "line-height: 28px;",
+		 components:[
+			 {name: "TextDiv",
+			  tag: "div",
+			  style: "height: 100%; margin: 0;",
+			  components: [
+				  {name: "Title",
+				   content: "Just Type Preferences"}
+			  ]}
+		 ]},
+		{kind: "Scroller",
+		 fit: true, touch: true, horizontal: "hidden",
+		 components: [{
+			 kind: "enyo.FittableRows",
+			 components: [
+				 {kind: "onyx.Groupbox", layoutKind: "FittableRowsLayout",
+				  name: "spg1", style: "padding: 35px 10% 0 10%;", components: [
+					  {kind: "onyx.GroupboxHeader", content: "Default Search Engine"},
+					  {kind: "enyo.FittableColumns", classes: "group-item",
+					   components: [
+						   {content: "", fit: true},
+						   {kind: "onyx.PickerDecorator", components: [
+							   {},
+							   {name: "SearchEnginePicker",
+							    kind: "onyx.Picker",
+							    onChange: "searchEngineChanged",
+							    components: []
+							   }
+						   ]}
+					   ]}
+				  ]}]}
+		             ]},
+		{kind: "onyx.Toolbar", components:[
+			{name: "Grabber", kind: "onyx.Grabber"},
+		]},
+		{kind: "enyo.LunaService", method: "getAllSearchPreference",
+		 name: "GetAllSearchPreference",
+		 service: "luna://com.palm.universalsearch",
+		 onComplete: "handleGetAllSearchPreferenceResponse"},
+		{kind: "enyo.LunaService", method: "getUniversalSearchList",
+		 name: "GetUniversalSearchList",
+		 service: "luna://com.palm.universalsearch",
+		 onComplete: "handleGetUniversalSearchListResponse"}
+	],
+	//Handlers
+	create: function(inSender, inEvent) {
+		this.inherited(arguments);
+		if(!window.PalmSystem) {
+			enyo.log("Non-palm platform, service requests disabled.");
+			return;
+		}
+		this.$.GetAllSearchPreference.send({});
+		this.$.GetUniversalSearchList.send({});
+		this.palm = true;
+	},
+	reflow: function(inSender) {
+		this.inherited(arguments);
+		if(enyo.Panels.isScreenNarrow()) {
+			this.$.Grabber.applyStyle("visibility", "hidden");
+			this.$.spg1.setStyle("padding: 35px 5% 0 5%;");
+		}
+		else {
+			this.$.Grabber.applyStyle("visibility", "visible");
+			this.$.spg1.setStyle("padding: 35px 10% 0 10%;");
+		}
+	},
+	//Action Handlers
+	searchEngineChanged: function(inSender, inEvent) {
+		if(this.palm) {
+		}
+		else {
+			this.log(inSender.selected);
+		}
+	},
+	//Service Callbacks
+	handleGetAllSearchPreferenceResponse: function(inSender, inResponse) {
+		if (inResponse.SearchPreference !== undefined &&
+		    inResponse.SearchPreference.defaultSearchEngine !== undefined) {
+			this.preferredSearch = inResponse.SearchPreference.defaultSearchEngine;
+		}
+	},
+	handleGetUniversalSearchListResponse: function(inSender, inResponse) {
+		if (inResponse["UniversalSearchList"] !== undefined) {
+			var i = 0;
+			for (var item in inResponse["UniversalSearchList"]) {
+				this.$.SearchEnginePicker.
+					createComponents({content: item.displayName},
+					                 {owner: this.$.SearchEnginePicker});
+				if (item.displayName === this.preferredSearch) {
+					this.$.SearchEnginePicker.getClientControls()[i].setActive(true);
+				}
+				++i;
+			}
+		}
+	}
+});

--- a/source/views/SearchPreferences.js
+++ b/source/views/SearchPreferences.js
@@ -25,9 +25,11 @@ enyo.kind({
 					  {kind: "onyx.GroupboxHeader", content: "Default Search Engine"},
 					  {kind: "enyo.FittableColumns", classes: "group-item",
 					   components: [
-						   {content: "", fit: true},
-						   {kind: "onyx.PickerDecorator", components: [
-							   {},
+						   {name: "searchEngineIcon", kind: "onyx.Icon",
+						    style: "width: 48px; height: 48px"},
+						   {kind: "onyx.PickerDecorator", fit: true,
+						    components: [
+							   {name: "SearchEngineButton"},
 							   {name: "SearchEnginePicker",
 							    kind: "onyx.Picker",
 							    onChange: "searchEngineChanged",
@@ -88,15 +90,30 @@ enyo.kind({
 	},
 	handleGetUniversalSearchListResponse: function(inSender, inResponse) {
 		if (inResponse["UniversalSearchList"] !== undefined) {
+			var newIx;
 			for (var i = 0; i < inResponse.UniversalSearchList.length; ++i) {
 				var item = inResponse.UniversalSearchList[i];
 				this.$.SearchEnginePicker.
 					createComponent({content: item.displayName});
-				if (item.displayName === this.preferredSearch) {
-					this.$.SearchEnginePicker.getClientControls()[i+1].setActive(true);
+				// We cannot rely on it that the built in preferred engine
+				// has been specified with the same case as it has been
+				// specified in the built in list of options. Hoorah!
+				if (item.displayName.toLowerCase() ===
+				    this.preferredSearch.toLowerCase()) {
+					newIx = i;
 				}
 			}
-			this.render();
+			if (typeof newIx !== "undefined") {
+				this.$.searchEngineIcon.setSrc(
+					inResponse.UniversalSearchList[newIx].iconFilePath);
+				newSel = this.$.SearchEnginePicker.getClientControls()[newIx];
+				this.$.SearchEnginePicker.silence();
+				this.$.SearchEnginePicker.setSelected(newSel);
+				this.$.SearchEnginePicker.unsilence();
+				this.$.SearchEngineButton.setContent(newSel.content);
+			}
+			this.$.SearchEngineIcon.render();
+			this.$.SearchEnginePicker.render();
 		}
 	}
 });

--- a/source/views/SearchPreferences.js
+++ b/source/views/SearchPreferences.js
@@ -47,11 +47,11 @@ enyo.kind({
 		{kind: "onyx.Toolbar", components:[
 			{name: "Grabber", kind: "onyx.Grabber"},
 		]},
-		{kind: "enyo.LunaService", method: "getAllSearchPreference",
+		{kind: "enyo.LunaService", method: "getAllSearchPreference", subscribe: true,
 		 name: "GetAllSearchPreference",
 		 service: "luna://com.palm.universalsearch",
 		 onComplete: "handleGetAllSearchPreferenceResponse"},
-		{kind: "enyo.LunaService", method: "getUniversalSearchList",
+		{kind: "enyo.LunaService", method: "getUniversalSearchList", subscribe: true,
 		 name: "GetUniversalSearchList",
 		 service: "luna://com.palm.universalsearch",
 		 onComplete: "handleGetUniversalSearchListResponse"},
@@ -87,10 +87,6 @@ enyo.kind({
 				this.$.SetSearchPreference.send({key: "defaultSearchEngine",
 				                                 value: inEvent.selected.content});
 				this.log("Set defaultSearchEngine " + inEvent.selected.content + " sent");
-				// A sure, if rather indirect, way to update the icon
-				// we are displaying
-				this.preferredSearch = inEvent.selected.content;
-				this.$.GetUniversalSearchList.send({});
 			}
 			else {
 				this.log("Set defaultSearchEngine " + inEvent.selected.content + " suppressed");

--- a/source/views/SearchPreferences.js
+++ b/source/views/SearchPreferences.js
@@ -57,7 +57,6 @@ enyo.kind({
 			return;
 		}
 		this.$.GetAllSearchPreference.send({});
-		this.$.GetUniversalSearchList.send({});
 		this.palm = true;
 	},
 	reflow: function(inSender) {
@@ -84,20 +83,20 @@ enyo.kind({
 		if (inResponse.SearchPreference !== undefined &&
 		    inResponse.SearchPreference.defaultSearchEngine !== undefined) {
 			this.preferredSearch = inResponse.SearchPreference.defaultSearchEngine;
+			this.$.GetUniversalSearchList.send({});
 		}
 	},
 	handleGetUniversalSearchListResponse: function(inSender, inResponse) {
 		if (inResponse["UniversalSearchList"] !== undefined) {
-			var i = 0;
-			for (var item in inResponse["UniversalSearchList"]) {
+			for (var i = 0; i < inResponse.UniversalSearchList.length; ++i) {
+				var item = inResponse.UniversalSearchList[i];
 				this.$.SearchEnginePicker.
-					createComponents({content: item.displayName},
-					                 {owner: this.$.SearchEnginePicker});
+					createComponent({content: item.displayName});
 				if (item.displayName === this.preferredSearch) {
-					this.$.SearchEnginePicker.getClientControls()[i].setActive(true);
+					this.$.SearchEnginePicker.getClientControls()[i+1].setActive(true);
 				}
-				++i;
 			}
+			this.render();
 		}
 	}
 });

--- a/source/views/Settings.js
+++ b/source/views/Settings.js
@@ -97,6 +97,7 @@ enyo.kind({
 				{kind: "ListItem", icon: "icon.png", title: "Screen & Lock", ontap: "openPanel", targetPanel: "ScreenLockPanel"},
 				{kind: "ListItem", icon: "icon.png", title: "Date & Time", ontap: "openPanel", targetPanel: "DateTimePanel"},
 				{kind: "ListItem", icon: "icon.png", title: "Sound & Ringtones", ontap: "openPanel", targetPanel: "AudioPanel"},
+				{kind: "ListItem", icon: "icon.png", title: "Search Preferences", ontap: "openPanel", targetPanel: "SearchPreferencesPanel"},
 				{kind: "ListItem", icon: "icon.png", title: "Language & Input", ontap: "openPanel", targetPanel: "LanguageInputPanel"},
 				{kind: "ListItem", name: "DevModemListItem", icon: "icon.png", title: "Developer Options", ontap: "openPanel", targetPanel: "DevOptionsPanel", showing: false},
 				{kind: "ListItem", icon: "icon.png", title: "About", ontap: "openPanel", targetPanel: "AboutPanel"}
@@ -116,6 +117,7 @@ enyo.kind({
 			{name: "ScreenLockPanel", kind: "ScreenLock"},
 			{name: "DateTimePanel", kind: "DateTime"},
 			{name: "AudioPanel", kind: "Sound"},
+			{name: "SearchPreferencesPanel", kind: "SearchPreferences"},
 			{name: "DevOptionsPanel", kind: "DevOptions"},
 			{name: "TelephonyPanel", kind: "Telephony"},
 			{name: "LanguageInputPanel", kind: "LanguageInput"},

--- a/source/views/package.js
+++ b/source/views/package.js
@@ -12,6 +12,7 @@ enyo.depends(
 	"DevOptions.js",
 	"DevModeService.js",
 	"DateTime.js",
+	"SearchPreferences.js",
 	"About.js",
 	"Certificates.js",
 	"Settings.js"


### PR DESCRIPTION
Addressing Issue 575 (very simply): Add a search preferences panel to show the current default search engine, to list the ones we know about and let the user pick one as the new default.

Note: The Settings app picks up the new default next time it is run so this is working I reckon. I haven't noticed anything else acknowledging the change (neither Just Type nor the web browser) though.