### PR TITLE
WiFi manually add network UI plus spinner consistency

### DIFF
--- a/source/views/Bluetooth.js
+++ b/source/views/Bluetooth.js
@@ -74,9 +74,9 @@ enyo.kind({
                         }, // icons
                         {
                             name: "ConnectingSpinner",
-                            kind: "Image",
-                            src: "assets/bluetooth/connecting.gif",
-                            style: "width: 32px; height: 32px; margin: 4px; padding-top: 4px;",
+                            kind: "onyx.Spinner",
+                            style: "width: 54px; height: 55px; margin: 4px; padding-top: 4px;",
+			    classes: "onyx-light",
                             showing: false
                         },
                     ]
@@ -167,7 +167,7 @@ var mockDevices = [
         name: "Phone",
         type: 3, //"phone",
         enabled: true,
-        connection: 1
+        connection: 2
     },
     {
         name: "Keyboard",
@@ -281,14 +281,14 @@ enyo.kind({
                             components: [
                                 {
                                     name: "DiscoverableSpinner",
-                                    kind: "Image",
-                                    src: "assets/bluetooth/connecting.gif",
-                                    style: "width: 32px; height: 32px; margin-right: 10px;"
+                                    kind: "onyx.Spinner",
+				    classes: "onyx-light",
+                                    style: "width: 54px; height: 55px; margin-right: 10px;"
                                 },
                                 {
                                     name: "DiscoverableStatusMessage",
                                     content: "Making your device visible and discoverable to others.", //"Your device is now discoverable."
-                                    style: "line-height: 30px;"
+                                    style: "line-height: 55px;"
                                 }
                             ]
                         },
@@ -300,14 +300,14 @@ enyo.kind({
                             components: [
                                 {
                                     name: "DiscoveringSpinner",
-                                    kind: "Image",
-                                    src: "assets/bluetooth/connecting.gif",
-                                    style: "width: 32px; height: 32px; margin-right: 10px;"
+                                    kind: "onyx.Spinner",
+				    classes: "onyx-light",
+                                    style: "width: 54px; height: 55px; margin-right: 10px;"
                                 },
                                 {
                                     name: "DiscoveringStatusMessage",
                                     content: "Searching for devices...",
-                                    style: "line-height: 30px;"
+                                    style: "line-height: 55px;"
                                 }
                             ]
                         },
@@ -513,14 +513,14 @@ enyo.kind({
                                     components: [
                                         {
                                             name: "SearchSpinner",
-                                            kind: "Image",
-                                            src: "assets/bluetooth/connecting.gif",
-                                            style: "width: 32px; height: 32px; margin-right: 10px;"
+                                            kind: "onyx.Spinner",
+					    classes: "onyx-light",
+                                            style: "width: 54px; height: 55px; margin-right: 10px;"
                                         },
                                         {
                                             name: "SearchStatusMessage",
                                             content: "Searching for audio devices...",
-                                            style: "line-height: 30px; font-size: 18px;"
+                                            style: "line-height: 55px; font-size: 18px;"
                                         }
                                     ]
                                 },

--- a/source/views/Bluetooth.js
+++ b/source/views/Bluetooth.js
@@ -30,7 +30,7 @@ enyo.kind({
             max: 110,
             unit: "%",
             value: 0,
-            style: "position:inherit; z-index:20; background-color: #EAEAEA; line-height: 38px;",
+            style: "position:inherit; z-index:20; background-color: #EAEAEA; line-height: 55px;",
             preventDragPropagation: false,
             newDevice: false,
             classes: "group-item",
@@ -46,7 +46,7 @@ enyo.kind({
                             name: "DeviceType",
                             kind: "Image",
                             src: "assets/bluetooth/other.png",
-                            style: "width: 32px; height: 32px; margin: 4px;",
+                            style: "width: 32px; height: 32px; margin-top: 11px !important",
                             ontap: "doDeviceTapped",
                             //TODO: classes
                         },
@@ -54,21 +54,21 @@ enyo.kind({
                             {
                                 name: "DeviceName",
                                 content: "DeviceName",
-                                style: "padding-left: 10px; line-height: 36px;",
+                                style: "padding-left: 10px; line-height: 55px;",
                                 ontap: "doDeviceTapped",
                                 onhold: "editDeviceName"
                             },
-                            {name: "DeviceNameInputDecorator", kind: "onyx.InputDecorator", style: "height: 18px;", showing: false, components: [
-                                {name: "DeviceNameInput", kind: "onyx.Input", placeholder: "DeviceName", style: "line-height: 24px;", selectOnFocus: true, onchange: "inputChange", onblur: "inputLostFocus"}
+                            {name: "DeviceNameInputDecorator", kind: "onyx.InputDecorator", style: "height: 55px;", showing: false, components: [
+                                {name: "DeviceNameInput", kind: "onyx.Input", placeholder: "DeviceName", style: "line-height: 55px;", selectOnFocus: true, onchange: "inputChange", onblur: "inputLostFocus"}
                             ]}
                         ]}, //Device Name
                         {
                             name: "MoreInfo",
                             kind: "enyo.Button",
                             showing: false,
-                            style: "margin-left: 10px;",
+                            style: "margin-left: 10px; margin-top: 11px !important",
                             components: [
-                                { kind: "Image", src: "assets/bluetooth/info.png", style: "width: 32px; height: 32px;"}
+                                { kind: "Image", src: "assets/bluetooth/info.png", style: "width: 32px; height: 32px"}
                             ],
                             ontap: "doInfoButtonTapped"
                         }, // icons
@@ -86,7 +86,7 @@ enyo.kind({
         {
             name: "SliderButtons",
             classes: "group-item",
-            style: "position:absolute; top:0px; z-index:10; line-height: 38px; text-align: center; width: 100%; background-image:url('assets/bg.png');", components: [
+            style: "position:absolute; top:0px; z-index:10; line-height: 55px; text-align: center; width: 100%; background-image:url('assets/bg.png');", components: [
                 {kind: "onyx.Button", content: "Cancel", ontap: "closeSlider"},
                 {kind: "onyx.Button", content: "Delete", classes: "onyx-negative", style: "margin-left: 10px;", ontap: "deleteDevice"}
             ],
@@ -271,13 +271,14 @@ enyo.kind({
                     ]
                 },
                 /* Device list panel */
+		/* 67px is spinner height (55) + 2 x padding (6) */
                 {
                     kind: "enyo.FittableRows",
                     components: [
                         {
                             name: "DiscoverableStatus",
                             kind: "enyo.FittableColumns",
-                            style: "padding: 35px 10% 0 10%;",
+                            style: "padding: 35px 10% 0 10%; height: 67px",
                             components: [
                                 {
                                     name: "DiscoverableSpinner",
@@ -288,7 +289,7 @@ enyo.kind({
                                 {
                                     name: "DiscoverableStatusMessage",
                                     content: "Making your device visible and discoverable to others.", //"Your device is now discoverable."
-                                    style: "line-height: 55px;"
+                                    style: "line-height: 55px; font-size: 14px"
                                 }
                             ]
                         },
@@ -296,7 +297,7 @@ enyo.kind({
                             name: "DiscoveringStatus",
 			    showing: false,
                             kind: "enyo.FittableColumns",
-                            style: "padding: 35px 10% 0 10%;",
+                            style: "padding: 35px 10% 0 10%; height: 67px",
                             components: [
                                 {
                                     name: "DiscoveringSpinner",
@@ -307,7 +308,7 @@ enyo.kind({
                                 {
                                     name: "DiscoveringStatusMessage",
                                     content: "Searching for devices...",
-                                    style: "line-height: 55px;"
+                                    style: "line-height: 55px; font-size: 14px"
                                 }
                             ]
                         },
@@ -520,7 +521,7 @@ enyo.kind({
                                         {
                                             name: "SearchStatusMessage",
                                             content: "Searching for audio devices...",
-                                            style: "line-height: 55px; font-size: 18px;"
+                                            style: "line-height: 55px; font-size: 14px;"
                                         }
                                     ]
                                 },

--- a/source/views/WiFi.js
+++ b/source/views/WiFi.js
@@ -607,7 +607,7 @@ enyo.kind({
     reflow: function (inSender) {
         this.inherited(arguments);
         if (enyo.Panels.isScreenNarrow()){
-        	this.$.NetworkList.setStyle("padding: 35px 5% 35px 5%;");
+            this.$.NetworkList.setStyle("padding: 35px 5% 35px 5%;");
             this.$.Grabber.applyStyle("visibility", "hidden");
         }else{
             this.$.Grabber.applyStyle("visibility", "visible");
@@ -649,7 +649,7 @@ enyo.kind({
             this.showNetworkConnect();
         } else {
             this.log("Connect to open network");
-            this.connectNetwork(this, {
+            this.connectNetwork({
                 path: this.currentNetwork.path,
                 password: ""
             });
@@ -672,7 +672,7 @@ enyo.kind({
         this.showNetworkConnect();
     },
     onJoinButtonTapped: function (inSender, inEvent) {
-		this.showJoinNetwork();
+	this.showJoinNetwork();
     },
     signalStrengthToBars: function(strength) {
         if(strength > 0 && strength < 34)
@@ -737,22 +737,22 @@ enyo.kind({
             inEvent.item.$.wiFiListItem.$.Signal.setSrc("assets/wifi/signal-icon-" + bars + ".png");
 		}
     },
-    setupKnownNetworkRow: function (inSender, inEvent) {
-    	var ssid = "";	
-	if(enyo.Panels.isScreenNarrow()){
-	    // if the SSID is longer shorten it for the narrow page only
-    	    if(this.foundNetworks[inEvent.index].name.length >= 18){
-    		ssid = this.foundNetworks[inEvent.index].name.slice(0,18) + "..";
-    	    }else{
-    		ssid = this.foundNetworks[inEvent.index].name;
-    	    }
-    	}else{
-    	    ssid = this.foundNetworks[inEvent.index].name;
-    	}
-        inEvent.item.$.wiFiListItem.$.SSID.setContent( ssid );
-        inEvent.item.$.wiFiListItem.$.Security.setContent(this.knownNetworks[inEvent.index].security);
-        inEvent.item.$.wiFiListItem.$.Signal.setShowing(false);
-    },
+//    setupKnownNetworkRow: function (inSender, inEvent) {
+//    	var ssid = "";
+//	if(enyo.Panels.isScreenNarrow()){
+//	    // if the SSID is longer shorten it for the narrow page only
+//    	    if(this.foundNetworks[inEvent.index].name.length >= 18){
+//    		ssid = this.foundNetworks[inEvent.index].name.slice(0,18) + "..";
+//    	    }else{
+//    		ssid = this.foundNetworks[inEvent.index].name;
+//    	    }
+//    	}else{
+//    	    ssid = this.foundNetworks[inEvent.index].name;
+//    	}
+//        inEvent.item.$.wiFiListItem.$.SSID.setContent( ssid );
+//        inEvent.item.$.wiFiListItem.$.Security.setContent(this.knownNetworks[inEvent.index].security);
+//        inEvent.item.$.wiFiListItem.$.Signal.setShowing(false);
+//    },
     onNetworkConnect: function (inSender, inEvent) {
 	var password = this.$.PasswordInput.getValue();
 	var passwordPlausible = this.validatePassword(password);
@@ -760,7 +760,7 @@ enyo.kind({
         if (!passwordPlausible) {
 	    this.showError("Entered password is invalid");
         } else {
-            this.connectNetwork(this, {
+            this.connectNetwork({
                 path: this.currentNetwork.path,
                 password: password
             });
@@ -773,11 +773,11 @@ enyo.kind({
     },
     onNetworkConnectAborted: function (inSender, inEvent) {
         // switch back to network list view
-        this.showNetworksList(inSender, inEvent);
+        this.showNetworksList();
 
         this.$.PasswordInput.setValue("");
     },
-    onOtherJoinConnectTapped: function() {
+    onOtherJoinConnectTapped: function(inSender, inEvent) {
 	if (this.$.ssidInput.getValue() !== "") {
             this.currentNetwork = {
 		ssid: this.$.ssidInput.getValue(),
@@ -797,7 +797,7 @@ enyo.kind({
 		this.showNetworkConnect();
             } else {
 		this.log("Connect to open network");
-		this.connectNetwork(this, {
+		this.connectNetwork({
                     path: this.currentNetwork.path,
                     password: ""
 		});
@@ -806,13 +806,13 @@ enyo.kind({
     },
     onOtherJoinCancelled: function (inSender, inEvent) {
         // switch back to network list view
-        this.showNetworksList(inSender, inEvent);
+        this.showNetworksList();
 
         this.$.ssidInput.setValue("");
         this.$.SecurityTypePicker.setSelected(this.$.OpenSecurityItem);
     },
     //Action Functions
-    showWiFiDisabled: function (inSender, inEvent) {
+    showWiFiDisabled: function () {
         this.stopAutoscan();
         this.$.WiFiPanels.setIndex(0);
     },
@@ -824,14 +824,15 @@ enyo.kind({
         this.$.WiFiPanels.setIndex(2);
         this.stopAutoscan();
     },
-    showJoinNetwork: function(inSender, inEvent) {
+    showJoinNetwork: function() {
         this.$.WiFiPanels.setIndex(3);
         this.stopAutoscan();
     },
-    showNetworkConfiguration: function (inSender, inEvent) {
+    showNetworkConfiguration: function () {
         this.$.WiFiPanels.setIndex(4);
         this.stopAutoscan();
     },
+    // Called by our parent.
     setToggleValue: function (value) {
         this.$.WiFiToggle.setValue(value);
     },
@@ -853,24 +854,26 @@ enyo.kind({
             return;
         navigator.WiFiManager.enabled = false;
     },
-    handleNetworkConnectSucceeded: function() {
-	},
-    handleNetworkConnectFailed: function() {
-	},
-    connectNetwork: function (inSender, inEvent) {
-        this.log("connectNetwork", inEvent);
+    handleNetworkConnectSucceeded: function(inSender, inEvent) {
+	this.log();
+    },
+    handleNetworkConnectFailed: function(inSender, inEvent) {
+	this.log();
+    },
+    connectNetwork: function (network) {
+        this.log(network);
 
         if (!this.palm)
             return;
 
         var networkToConnect = {
-            path: inEvent.path,
+            path: network.path,
             hidden: false,
             security: "",
             password: ""
         };
 
-        if (inEvent.password != "") {
+        if (network.password != "") {
             this.log("Connecting to PSK network");
             networkToConnect.security = "psk";
             networkToConnect.password = inEvent.password;
@@ -893,28 +896,22 @@ enyo.kind({
         this.showNetworksList();
     },
     updateSpinnerState: function(action) {
-		this.log("action:", action);
-		
-		if (action === "start" ){
-			this.$.networkSearch.show();
-		}else{
-			this.$.networkSearch.hide();
-		}
+	if (action === "start"){
+	    this.$.networkSearch.show();
+	}else{
+	    this.$.networkSearch.hide();
+	}
     },
-
-    handleBackGesture: function(inSender, inEvent) {
-		this.log("sender:", inSender, ", event:", inEvent);	
-		
-		if(this.$.WiFiPanels.getIndex() > 1){
-			this.$.WiFiPanels.setIndex(1);
-			this.updateSpinnerState();					// stop the spinner
-		}else{
-			if( this.$.WiFiPanels.getIndex() === 1 || this.$.WiFiPanels.getIndex() === 0){
-				this.doBackbutton();
-				this.updateSpinnerState();				// stop the spinner
-			}
-		}
-	},
+    handleBackGesture: function() {
+	if(this.$.WiFiPanels.getIndex() > 1){
+	    this.$.WiFiPanels.setIndex(1);
+	    this.updateSpinnerState();				// stop the spinner
+	}else if( this.$.WiFiPanels.getIndex() === 1 ||
+		  this.$.WiFiPanels.getIndex() === 0){
+	    this.doBackbutton();
+	    this.updateSpinnerState();				// stop the spinner
+	}
+    },
 
     //Utility Functions
     clearFoundNetworks: function () {
@@ -940,9 +937,9 @@ enyo.kind({
             }
         }
     },
-    triggerAutoscan: function() {
-		this.updateSpinnerState("start");
-		if (!navigator.WiFiManager)
+    triggerAutoscan: function(inSender, inEvent) {
+	this.updateSpinnerState("start");
+	if (!navigator.WiFiManager)
             return;
         navigator.WiFiManager.retrieveNetworks(enyo.bind(this, "handleRetrieveNetworksResponse"),
                                                enyo.bind(this, "handleRetrieveNetworksFailed"));
@@ -967,6 +964,7 @@ enyo.kind({
         }
     },
     handleRetrieveNetworksFailed: function() {
+	log.this(); // Worth a mention. Surely?
         this.clearFoundNetworks();
     },
     // Not convinced this happens if the WiFi status is changed

--- a/source/views/WiFi.js
+++ b/source/views/WiFi.js
@@ -235,8 +235,8 @@ enyo.kind({
                                     }]
                                 },
                                 {name: "networkSearch", kind: "enyo.FittableColumns", showing: false, classes: "wifi-join-button", components: [
-									{content: "Searching for networks", fit: true, classes: "networkSearch"},
-									{name: "spin2",	kind: "onyx.Spinner", showing: true, style: "padding: 30px;", classes: "onyx-light" },
+				    {content: "Searching for networks", fit: true, classes: "networkSearch"},
+				    {name: "spin2",	kind: "onyx.Spinner", showing: true, style: "padding: 30px;", classes: "onyx-light" },
                                 ]},				//network search spinner
                                 {
                                     name: "JoinButton",


### PR DESCRIPTION
Adding a WiFi network manually is now largely enabled except that the WifiManager plugin seems to lack support for that. So, to be continued... I have added a warning label that is not implemented yet.

The Bluetooth panel was using its own spinner gif. I have modified it to use the same onyx.Spinner as the rest of the app. That's a bit bigger though, so I had to hack the layout a bit.