### PR TITLE
Unify layout

### DIFF
--- a/source/package.js
+++ b/source/package.js
@@ -1,7 +1,7 @@
 enyo.depends(
 	"$lib/layout",
-	"$lib/onyx",	// To theme Onyx using Theme.less, change this line to $lib/onyx/source,
-	//"Theme.less",	// uncomment this line, and follow the steps described in Theme.less
+	"$lib/onyx/source",	// To theme Onyx using Theme.less, change this line to $lib/onyx/source,
+	"style/Theme.less",	// uncomment this line, and follow the steps described in Theme.less
 	"$lib/more-arrangers",
 	"$lib/enyo-webos",
 	"$lib/webos-lib",

--- a/source/style/Theme.less
+++ b/source/style/Theme.less
@@ -16,6 +16,8 @@
 
 /* Place your Onyx variable overrides here -------------------- */
 
+@onyx-togglebutton-background: #82bef1;
+
 /* ------------------------------------- end variable overrides */
 
 /* Onyx rule definitions: */


### PR DESCRIPTION
Legacy Enyo 1.0 and QML apps use a blue background for toggle button, so
we want to use the same in Enyo 2.0 apps for consistency.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>