### PR TITLE
appinfo.json: Add visible flags

### DIFF
--- a/data/appinfo.backup.json
+++ b/data/appinfo.backup.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-backup.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.bluetooth.json
+++ b/data/appinfo.bluetooth.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-bluetooth.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.certificate.json
+++ b/data/appinfo.certificate.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-certificate.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.dateandtime.json
+++ b/data/appinfo.dateandtime.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-dateandtime.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.deviceinfo.json
+++ b/data/appinfo.deviceinfo.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-deviceinfo.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.devmodeswitcher.json
+++ b/data/appinfo.devmodeswitcher.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-devmodeswitcher.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.exhibitionpreferences.json
+++ b/data/appinfo.exhibitionpreferences.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-exhibitionpreferences.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.help.json
+++ b/data/appinfo.help.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-help.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.languagepicker.json
+++ b/data/appinfo.languagepicker.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-languagepicker.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.location.json
+++ b/data/appinfo.location.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-location.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.networksettings.json
+++ b/data/appinfo.networksettings.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-networksettings.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.screenlock.json
+++ b/data/appinfo.screenlock.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-screenlock.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.searchpreferences.json
+++ b/data/appinfo.searchpreferences.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-searchpreferences.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.soundsandalerts.json
+++ b/data/appinfo.soundsandalerts.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-soundsandalerts.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.textassist.json
+++ b/data/appinfo.textassist.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-textassist.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.updates.json
+++ b/data/appinfo.updates.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-updates.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.vpn.json
+++ b/data/appinfo.vpn.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-vpn.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 

--- a/data/appinfo.wifi.json
+++ b/data/appinfo.wifi.json
@@ -8,6 +8,7 @@
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-wifi.png",
-    "uiRevision": "2"
+    "uiRevision": "2",
+    "visible": "true"
 }
 


### PR DESCRIPTION
This will allow us to make an app visible or invisible in the launcher and can help with the one app v.s. multiple apps option for Settings.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>