### PR TITLE
Enable manual time and date in Settings

### DIFF
--- a/source/views/DateTime.js
+++ b/source/views/DateTime.js
@@ -70,11 +70,11 @@ enyo.kind({
 					]},
 					{ name: "TimePickerRow", kind: "enyo.FittableColumns", classes: "group-item", components:[
 						{content: "Time", fit: true},
-						{name: "TimePicker", kind: "onyx.TimePicker", disabled: true, onSelect: "dateTimeChanged"},
+						{name: "TimePicker", kind: "onyx.TimePicker", onSelect: "dateTimeChanged"},
 					]},
 					{ name: "DatePickerRow", kind: "enyo.FittableColumns", classes: "group-item", components:[
 						{content: "Date", fit: true},
-						{name: "DatePicker", kind: "onyx.DatePicker", disabled: true, onSelect: "dateTimeChanged"},
+						{name: "DatePicker", kind: "onyx.DatePicker", onSelect: "dateTimeChanged"},
 					]}
 				]},
 				{kind: "onyx.Groupbox", layoutKind: "FittableRowsLayout",


### PR DESCRIPTION
It is useful to be able to set the time by hand if you don't have a SIM or your device is not picking up the correct date and time automatically even if you do. This is particularly true for devices with a non-writable RTC stuck in the 1970s.

I know we are aiming to reimplement Settings in QML, but this code works already.