### PR TITLE
appinfo.networksettings.json: Add networking.query

### DIFF
--- a/data/appinfo.networksettings.json
+++ b/data/appinfo.networksettings.json
@@ -10,6 +10,5 @@
     "icon": "qml/images/icons/icon-networksettings.png",
     "uiRevision": "2",
     "visible": "true",
-    "requiredPermissions": ["networking"]
+    "requiredPermissions": ["networking", "networking.query", "networking.internal"]
 }
-


### PR DESCRIPTION
Fixes:

2020-06-22T16:02:13.121101Z [808.571276130] user.warning webos-telephonyd [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.settings.networksettings-1206","CATEGORY":"/","METHOD":"getstatus"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>