### PR TITLE
org.webosports.app.settings: Fix various errors

### DIFF
--- a/src/qml/Connectivity/BluetoothPage.qml
+++ b/src/qml/Connectivity/BluetoothPage.qml
@@ -90,7 +90,7 @@ BasePage {
 
     Connections {
         target: BluetoothManager
-        onBluetoothOperationalChanged: {
+        function onBluetoothOperationalChanged() {
             console.log("BluetoothManager.bluetoothOperational="+BluetoothManager.bluetoothOperational);
             btAgent.registerToManager(BluetoothManager.btManager);
         }
@@ -104,7 +104,9 @@ BasePage {
 
             Connections {
                 target: BluetoothManager
-                onPoweredChanged: bluetoothPowerSwitch.checked=BluetoothManager.powered;
+                function onPoweredChanged() {
+                    bluetoothPowerSwitch.checked=BluetoothManager.powered;
+                }
             }
             checked: BluetoothManager.powered
             onCheckedChanged: BluetoothManager.powered = checked;
@@ -119,9 +121,7 @@ BasePage {
 
             text: "Discoverable"
 
-            anchors.left: parent.left
-            anchors.right: parent.right
-
+            Layout.fillWidth: true
             LayoutMirroring.enabled: true
             LuneOSSwitch.labelOn: "On"
             LuneOSSwitch.labelOff: "Off"
@@ -134,9 +134,8 @@ BasePage {
 
         /* GroupBoxes look good! */
         GroupBox {
-            anchors.left: parent.left
-            anchors.right: parent.right
             Layout.fillHeight: true
+            Layout.fillWidth: true
 
             title: "Choose a device"
             ColumnLayout {

--- a/src/qml/Connectivity/WiFiPage.qml
+++ b/src/qml/Connectivity/WiFiPage.qml
@@ -48,7 +48,9 @@ BasePage {
 
             Connections {
                 target: wifiModel
-                onPoweredChanged: wifiPowerSwitch.checked=wifiModel.powered;
+                function onPoweredChanged () {
+                    wifiPowerSwitch.checked=wifiModel.powered;
+                }
             }
             checked: wifiModel.powered
             onCheckedChanged: wifiModel.powered=checked;

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -32,7 +32,9 @@ GenericCategoryWindow {
 
     Connections {
         target: _categoryLoader
-        onLoaded: categoryChooserDrawer.close();
+        function onLoaded() {
+            categoryChooserDrawer.close();
+        }
     }
 
     ListModel {


### PR DESCRIPTION
Addresses things like:

org.webosports.app.settings/src/qml/main.qml:33:5: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }

org.webosports.app.settings/src/qml/Connectivity/BluetoothPage.qml:117:9: QML Switch: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>