### PR TITLE
appinfo.json: Fix schema validation for webOS OSE's SAM

### DIFF
--- a/data/appinfo.backup.json
+++ b/data/appinfo.backup.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.backup",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-backup.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.bluetooth.json
+++ b/data/appinfo.bluetooth.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.bluetooth",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-bluetooth.png",
     "uiRevision": "2",
-    "visible": "true"
+    "visible": true
 }
 

--- a/data/appinfo.certificate.json
+++ b/data/appinfo.certificate.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.certificate",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-certificate.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.dateandtime.json
+++ b/data/appinfo.dateandtime.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.dateandtime",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-dateandtime.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.deviceinfo.json
+++ b/data/appinfo.deviceinfo.json
@@ -3,13 +3,13 @@
     "id": "org.webosports.app.settings.deviceinfo",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-deviceinfo.png",
     "uiRevision": "2",
-    "visible": "true",
+    "visible": true,
     "requiredPermissions": ["system", "networking", "networking.query", "settings"]
 }
 

--- a/data/appinfo.devmodeswitcher.json
+++ b/data/appinfo.devmodeswitcher.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.devmodeswitcher",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-devmodeswitcher.png",
     "uiRevision": "2",
-    "visible": "true"
+    "visible": true
 }
 

--- a/data/appinfo.exhibitionpreferences.json
+++ b/data/appinfo.exhibitionpreferences.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.exhibitionpreferences",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-exhibitionpreferences.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.help.json
+++ b/data/appinfo.help.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.help",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-help.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.languagepicker.json
+++ b/data/appinfo.languagepicker.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.languagepicker",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-languagepicker.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.location.json
+++ b/data/appinfo.location.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.location",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-location.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.networksettings.json
+++ b/data/appinfo.networksettings.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.networksettings",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-networksettings.png",
     "uiRevision": "2",
-    "visible": "true",
+    "visible": true,
     "requiredPermissions": ["networking", "networking.query", "networking.internal"]
 }

--- a/data/appinfo.screenlock.json
+++ b/data/appinfo.screenlock.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.screenlock",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-screenlock.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.searchpreferences.json
+++ b/data/appinfo.searchpreferences.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.searchpreferences",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-searchpreferences.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.soundsandalerts.json
+++ b/data/appinfo.soundsandalerts.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.soundsandalerts",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-soundsandalerts.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.textassist.json
+++ b/data/appinfo.textassist.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.textassist",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-textassist.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.updates.json
+++ b/data/appinfo.updates.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.updates",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-updates.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.vpn.json
+++ b/data/appinfo.vpn.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.vpn",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-vpn.png",
     "uiRevision": "2",
-    "visible": "false"
+    "visible": false
 }
 

--- a/data/appinfo.wifi.json
+++ b/data/appinfo.wifi.json
@@ -3,12 +3,12 @@
     "id": "org.webosports.app.settings.wifi",
     "version": "0.4.0",
     "vendor": "WebOS Ports",
-    "vendor_url": "https://github.com/webOS-ports/org.webosports.app.settings",
+    "vendorurl": "https://github.com/webOS-ports/org.webosports.app.settings",
     "type": "qml",
     "useLuneOSStyle": true,
     "main": "qml/GenericCategoryWindow.qml",
     "icon": "qml/images/icons/icon-wifi.png",
     "uiRevision": "2",
-    "visible": "true"
+    "visible": true
 }
 


### PR DESCRIPTION
SAM expects vendorurl instead of vendor_url and visible to be a boolean as per schema:

https://github.com/webOS-ports/sam/blob/webOS-ports/webOS-OSE/files/schema/ApplicationDescription.schema

Fixes the icons not showing up in launcher when using SAM.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>