### PR TITLE
CMakeLists.txt: Update for Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,12 @@ include(webOS/webOS)
 webos_modules_init(1 0 0 QUALIFIER RC3)
 webos_component(0 4 0)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -Wall -std=c++0x")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -Wall -std=c++1z")
 
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Qml REQUIRED)
-find_package(Qt5Quick REQUIRED)
+find_package(Qt6 COMPONENTS Core Qml Quick REQUIRED)
+if (NOT Qt6_FOUND)
+    find_package(Qt5 5.15 REQUIRED COMPONENTS Core Qml Quick)
+endif()
 
 find_package(PkgConfig "0.22" REQUIRED)
 

--- a/src/qml/Common/BasePage.qml
+++ b/src/qml/Common/BasePage.qml
@@ -36,7 +36,7 @@ Page {
 
     // Convenience LS2 services & functions
     property LunaService luna: LunaService {
-        name: application.appInfo.id
+        name: appId
     }
 
     function _handleGetError(message) {


### PR DESCRIPTION
Make it more flexible so it works with both Qt5 and Qt6 as per:

https://doc-snapshots.qt.io/qt6-dev/cmake-qt5-and-qt6-compatibility.html

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>