### PR TITLE
org.webosports.app.settings: Migrate to Enhanced ACG

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -8,5 +8,5 @@
   "main": "index.html",
   "icon": "icon.png",
   "uiRevision": "2",
-  "requiredPermissions": ["settings", "networking", "networking.internal", "applications", "services", "devices", "database", "media", "system", "database.internal"]
+  "requiredPermissions": ["android-property-service.operation", "audio.operation", "audio.management", "certmgr-service.operation", "database.operation", "devmode-service.operation", "license-service.operation", "luna-sysmgr.operation", "networkconnection.management", "networkconnection.query", "systemsettings.management","systemsettings.query", "telephony.management", "universalsearch.operation", "update-service.operation", "wifi.management", "wifi.query"]
 }


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
