### PR TITLE
NetworkSettingsPage: fix getstatus LS2 call

### DIFF
--- a/src/qml/Connectivity/NetworkSettingsPage.qml
+++ b/src/qml/Connectivity/NetworkSettingsPage.qml
@@ -131,11 +131,11 @@ BasePage {
      */
     // Initialization and eventual subscription
     function retrieveProperties() {
-        luna.call("luna://com.palm.wan/getstatus", '{"subscribe": "true"}', _handleWanStatus, _handleGetError);
+        luna.subscribe("luna://com.palm.wan/getstatus", '{"subscribe": true}', _handleWanStatus, _handleGetError);
     }
     function _handleWanStatus(message) {
         if(message && message.payload) {
-            payloadValue = JSON.parse(message.payload);
+            let payloadValue = JSON.parse(message.payload);
             if(typeof payloadValue.roamguard !== 'undefined') {
                 roamingAllowed = (payloadValue.roamguard === "disable");
             }


### PR DESCRIPTION
Fixes: webos-telephonyd[1644]: [] [pmlog] <default-lib> LS_INVAL_JSON {"COND":"jis_boolean(sub_object)","FILE":"/usr/src/debug/luna-service2/3.21.2-34+gitAUTOINC+e59ad3680b-r32/git/src/libluna-service2/message.c"} jis_boolean(sub_object): failed.