### PR TITLE
appinfo.deviceinfo.json: Add permissions for android-property-service

### DIFF
--- a/data/appinfo.deviceinfo.json
+++ b/data/appinfo.deviceinfo.json
@@ -11,6 +11,6 @@
     "icon": "qml/images/icons/icon-deviceinfo.png",
     "uiRevision": "2",
     "visible": true,
-    "requiredPermissions": ["networkconnection.query", "networkconnection.management", "preferences.system", "update-service.operation", "wifi.query", "wifi.management"]
+    "requiredPermissions": ["android-property-service.operation", "networkconnection.query", "networkconnection.management", "preferences.system", "update-service.operation", "wifi.query", "wifi.management"]
 }
 


### PR DESCRIPTION
Fixes:

Dec 04 18:09:22 mido-halium android-property-service[26900]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.settings.deviceinfo-26904","CATEGORY":"/","METHOD":"getProperty"} Service security groups don't allow method call.