### PR TITLE
org.webosports.app.settings: Disable functions no longer in use

### DIFF
--- a/source/views/DevOptions.js
+++ b/source/views/DevOptions.js
@@ -59,8 +59,8 @@ enyo.kind({
 												{ name: "ScreenOffToggle",  kind:"onyx.ToggleButton", onContent: "Yes", offContent: "No", classes: "onyx-toggle-button", onChange:"screenOffToggleChanged" },
 												{kind: "onyx.Tooltip", content: "Screen on when connected to usb"}
 											]}
-										]},										
-									]},
+										]},
+									]}/*,
 								{kind: "onyx.Groupbox", components: [
 									{kind: "onyx.GroupboxHeader", content: "Graphics"},
 									{kind: "enyo.FittableColumns", classes: "group-item", components:[
@@ -77,7 +77,7 @@ enyo.kind({
 											{kind: "onyx.Tooltip", content: "Enable Performance UI"}
 										]}
 									]}
-								]}
+								]}*/
 							]
 						}
 					]
@@ -89,9 +89,9 @@ enyo.kind({
 		]},
 		{name: "GetDevModeStatus", kind: "DevModeService", method: "getStatus", onComplete: "onGetDevModeStatusResponse"},
 		{name: "SetDevModeStatus", kind: "DevModeService", method: "setStatus", onComplete: "onSetDevModeStatusResponse"},
-		{name: "ShowFps", kind: "enyo.LunaService", service: "luna://org.webosports.luna/", method: "showFps"},
+		/*{name: "ShowFps", kind: "enyo.LunaService", service: "luna://org.webosports.luna/", method: "showFps"},
 		{name: "ShowPerformanceUI", kind: "enyo.LunaService", service: "luna://org.webosports.luna/", method: "showPerformanceUI"},
-		{name: "GetGraphicsStatus", kind: "enyo.LunaService", service: "luna://org.webosports.luna/", subscribe: true, method: "getStatus", onComplete: "onGetGraphicsStatusResponse"},
+		{name: "GetGraphicsStatus", kind: "enyo.LunaService", service: "luna://org.webosports.luna/", subscribe: true, method: "getStatus", onComplete: "onGetGraphicsStatusResponse"},*/
 		{name: "GetDisplayProperty", kind: "DisplayService", method: "getProperty", onComplete: "handleGetPropertiesResponse"},
 		{name: "SetDisplayProperty", kind: "DisplayService", method: "setProperty" }
 	],
@@ -104,7 +104,7 @@ enyo.kind({
 		this.palm = true;
 		this.$.GetDisplayProperty.send({properties: ["maximumBrightness", "timeout", "onWhenConnected"]});
 		this.$.GetDevModeStatus.send({});
-		this.$.GetGraphicsStatus.send({});
+		//this.$.GetGraphicsStatus.send({});
 	},
 	reflow: function (inSender) {
 		this.inherited(arguments);
@@ -134,7 +134,7 @@ enyo.kind({
 			return;
 		this.$.SetDevModeStatus.send({"usbDebugging": inEvent.value ? "enabled" : "disabled"});
 	},
-	onFpsCounterChanged: function (inSender, inEvent) {
+	/*onFpsCounterChanged: function (inSender, inEvent) {
 		console.log("onFpsCounterChanged");
 		if (!this.palm)
 			return;
@@ -145,7 +145,7 @@ enyo.kind({
 		if (!this.palm)
 			return;
 		this.$.ShowPerformanceUI.send({"visible":inEvent.value});
-	},
+	},*/
 	/* Service response handlers */
 	onGetDevModeStatusResponse: function (inSender, inResponse) {
 		this.log(inResponse);
@@ -162,11 +162,11 @@ enyo.kind({
 	},
 	onSetDevModeStatusResponse: function(inSender, inEvent) {
 		this.$.GetDevModeStatus.send({});
-	},
+	},/*
 	onGetGraphicsStatusResponse: function(inSender, inResponse) {
 		this.$.FpsCounterToggle.setValue(inResponse.fps);
 		this.$.PerformanceUIToggle.setValue(inResponse.performanceUI);
-	},
+	},*/
 	screenOffToggleChanged: function(inSender, inEvent) {
 		this.log("sender:", inSender, ", event:", inEvent);
 		

--- a/source/views/Settings.js
+++ b/source/views/Settings.js
@@ -75,7 +75,7 @@ enyo.kind({
 			components:[
 				//Connectivity
 				{kind: "onyx.Toolbar", classes: "list-header", content: "Connectivity"},
-				{kind: "ListItem", icon: "assets/icons/icon-wifi.png", title: "Wi-Fi", ontap: "openPanel", targetPanel: "WiFiPanel",
+				/*{kind: "ListItem", icon: "assets/icons/icon-wifi.png", title: "Wi-Fi", ontap: "openPanel", targetPanel: "WiFiPanel",
 				components:[
 					{name: "WiFiToggle",
 					kind: "onyx.ToggleButton",
@@ -88,7 +88,7 @@ enyo.kind({
 					kind: "onyx.ToggleButton",
 					ontap: "bluetoothToggleChanged",
 					style: "position: absolute; top: 11px; right: 9px; height: 31px;" }
-				]},
+				]},*/
 				{kind: "ListItem", icon: "assets/icons/icon-telephony.png", title: "Telephony", ontap: "openPanel", targetPanel: "TelephonyPanel"},
 
 				//Services
@@ -126,8 +126,8 @@ enyo.kind({
 		index: 1,
 		components:[
 			{kind: "EmptyPanel"},
-			{name: "WiFiPanel", kind: "WiFi", onActiveChanged: "wifiActiveChanged"},
-			{name: "BluetoothPanel", kind: "Bluetooth", onActiveChanged: "bluetoothActiveChanged"},
+			/*{name: "WiFiPanel", kind: "WiFi", onActiveChanged: "wifiActiveChanged"},
+			{name: "BluetoothPanel", kind: "Bluetooth", onActiveChanged: "bluetoothActiveChanged"},*/
 			{name: "SystemUpdatesPanel", kind: "SystemUpdates"},
 			{name: "CertificatesPanel", kind: "Certificates"},
 			{name: "ScreenLockPanel", kind: "ScreenLock"},
@@ -146,7 +146,7 @@ enyo.kind({
 		this.$.GetDevModeStatus.send({});
 	},
 	//Action Functions
-	wifiActiveChanged: function(inSender, inEvent) {
+	/*wifiActiveChanged: function(inSender, inEvent) {
 		this.$.WiFiToggle.silence();
 		this.$.WiFiToggle.setValue(inEvent.value);
 		this.$.WiFiToggle.unsilence();
@@ -163,7 +163,7 @@ enyo.kind({
 	bluetoothToggleChanged: function(inObj) {
 		this.$.BluetoothPanel.setToggleValue(inObj.value);
 		return true;
-	},
+	},*/
 	muteChanged: function(inSender, inEvent) {
 		this.$.muteToggle.silence();
 		this.$.muteToggle.setValue(inEvent.mute);
@@ -204,10 +204,10 @@ enyo.kind({
 	handleBack: function() {
 		if (this.currentPanel === "AboutPanel")
 			this.$.AboutPanel.handleBackGesture();
-		else if (this.currentPanel === "WiFiPanel" )
+		/*else if (this.currentPanel === "WiFiPanel" )
 			this.$.WiFiPanel.handleBackGesture();
 		else if (this.currentPanel === "BluetoothPanel" )
-			this.$.BluetoothPanel.handleBackGesture();
+			this.$.BluetoothPanel.handleBackGesture();*/
 		else if (this.currentPanel === "CertificatesPanel")
 			this.$.CertificatesPanel.handleBackGesture();
 		else if (this.currentPanel === "DateTimePanel")
@@ -250,16 +250,16 @@ enyo.kind({
 		if(enyo.Panels.isScreenNarrow()) {
 			this.$.AppPanels.setDraggable(false);
 			this.$.AppPanels.$.ContentPanels.applyStyle("box-shadow", "0");
-			this.$.AppPanels.$.WiFiToggle.setShowing(true);
-			this.$.AppPanels.$.BluetoothToggle.setShowing(true);
+			/*this.$.AppPanels.$.WiFiToggle.setShowing(true);
+			this.$.AppPanels.$.BluetoothToggle.setShowing(true);*/
 			this.$.AppPanels.$.muteLabel.setShowing(true);
 			this.$.AppPanels.$.muteToggle.setShowing(true);
 		}
 		else {
 			this.$.AppPanels.setDraggable(true);
 			this.$.AppPanels.$.ContentPanels.applyStyle("box-shadow", "-4px 0px 4px rgba(0,0,0,0.3)");
-			this.$.AppPanels.$.WiFiToggle.setShowing(false);
-			this.$.AppPanels.$.BluetoothToggle.setShowing(false);
+			/*this.$.AppPanels.$.WiFiToggle.setShowing(false);
+			this.$.AppPanels.$.BluetoothToggle.setShowing(false);*/
 			this.$.AppPanels.$.muteLabel.setShowing(false);
 			this.$.AppPanels.$.muteToggle.setShowing(false);
 		}
@@ -273,12 +273,12 @@ enyo.kind({
 			var targetPanelName = params.page + "Panel";
 			this.log("Switching to panel " + targetPanelName);
 			this.$.AppPanels.openPanel({ targetPanel: targetPanelName });
-		} else if (typeof(params.target) !== 'undefined' &&
+		}/* else if (typeof(params.target) !== 'undefined' &&
 			typeof(params.target.ssid) !== 'undefined' &&
 			typeof(params.target.securityType !== 'undefined')) {
 			this.$.AppPanels.openPanel({targetPanel:"WiFiPanel"});
 			this.$.AppPanels.$.WiFiPanel.wifiTarget = params.target;
-		}
+		}*/
 	},
 	handleBackGesture: function(inSender, inEvent) {
 		this.log("sender:", inSender, ", event:", inEvent);


### PR DESCRIPTION
We do WiFi & BT in Settings QML app now, so remove from here, same for functions no longer in use from now deprecated luna-next.

Just commented out the bits for now, we might get some inspiration for QML equivalents of some bits still (launchParams for example for WiFi).

